### PR TITLE
Update Discord webhook URL path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ bash <(curl -s https://raw.githubusercontent.com/rix4uni/GarudRecon/main/configu
   <summary><b>✅ Discord Webhook Setup</b></summary>
 
 ```yaml
-👉 Add all discord webhook url in ~/.bashrc:
+👉 Add all discord webhook url in /root/.config/notify/provider-config.yaml:
 discord:
   - id: "manualcheck"
     discord_channel: "manualcheck"


### PR DESCRIPTION
Update the path in the readme for Discord webhook settings to the correct path  which is being referenced by notify to send the messages to the discord server